### PR TITLE
use csi-plugin image for the node-init instead of busybox

### DIFF
--- a/controllers/images.go
+++ b/controllers/images.go
@@ -9,5 +9,4 @@ const (
 	csiNodeDriverRegistrarImage = "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1"
 	snapshotControllerImage     = "k8s.gcr.io/sig-storage/snapshot-controller:v4.1.0"
 	csiSnapshotterImage         = "k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.0"
-	busyboxImage                = "busybox:1.32"
 )

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -569,7 +569,7 @@ var (
 
 	nodeInitContainer = corev1.Container{
 		Name:            "init-nvme-tcp",
-		Image:           busyboxImage,
+		Image:           lbCSIPluginImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{Privileged: pointer.Bool(true)},
 		VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
to match actual helm charts