### PR TITLE
Add gardener system-component annotation to deployments and statefulset.

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -803,6 +803,7 @@ var (
 						"app":                                    lbCSINodeName,
 						"role":                                   "node",
 						"node.gardener.cloud/critical-component": "true",
+						"gardener.cloud/role":                    "system-component",
 					},
 					Annotations: map[string]string{"node.gardener.cloud/wait-for-csi-node-lightbits": provisioner},
 				},
@@ -1090,7 +1091,6 @@ func (r *DurosReconciler) deployCSI(ctx context.Context, projectID string, scs [
 			// cannot be used as we don't have a deletion flow
 			// https://github.com/metal-stack/duros-controller/pull/28
 			// "shoot.gardener.cloud/no-cleanup":        "true",
-			"gardener.cloud/role":                    "system-component",
 			"node.gardener.cloud/critical-component": "true",
 		}
 		ds.Spec = csiNodeDaemonSet.Spec

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -1043,7 +1043,7 @@ func (r *DurosReconciler) deployCSI(ctx context.Context, projectID string, scs [
 		},
 	}
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Shoot, sts, func() error {
-		controllerRoleLabels := map[string]string{"app": "lb-csi-plugin", "role": "controller"}
+		controllerRoleLabels := map[string]string{"app": "lb-csi-plugin", "role": "controller", "gardener.cloud/role": "system-component"}
 		containers := []corev1.Container{
 			csiPluginContainer,
 			csiProvisionerContainer,
@@ -1090,6 +1090,7 @@ func (r *DurosReconciler) deployCSI(ctx context.Context, projectID string, scs [
 			// cannot be used as we don't have a deletion flow
 			// https://github.com/metal-stack/duros-controller/pull/28
 			// "shoot.gardener.cloud/no-cleanup":        "true",
+			"gardener.cloud/role":                    "system-component",
 			"node.gardener.cloud/critical-component": "true",
 		}
 		ds.Spec = csiNodeDaemonSet.Spec


### PR DESCRIPTION
This should prevent the self-blocking deletion flow behavior:

[Screencast from 02.04.2024 14:20:17.webm](https://github.com/metal-stack/duros-controller/assets/15035165/8059adb5-7a51-4a21-8209-7a6844a5b63b)
