### PR TITLE
Add missing permission to snapshot controller.

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -279,6 +279,11 @@ var (
 					Resources: []string{"volumesnapshots/status"},
 					Verbs:     []string{"update", "patch"},
 				},
+				{
+					APIGroups: []string{"snapshot.storage.k8s.io"},
+					Resources: []string{"volumesnapshotcontents/status"},
+					Verbs:     []string{"update", "patch"},
+				},
 			},
 		}
 	}
@@ -307,11 +312,6 @@ var (
 					APIGroups: []string{"snapshot.storage.k8s.io"},
 					Resources: []string{"volumesnapshotcontents"},
 					Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
-				},
-				{
-					APIGroups: []string{"snapshot.storage.k8s.io"},
-					Resources: []string{"volumesnapshotcontents/status"},
-					Verbs:     []string{"update"},
 				},
 			},
 		}

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -277,7 +277,7 @@ var (
 				{
 					APIGroups: []string{"snapshot.storage.k8s.io"},
 					Resources: []string{"volumesnapshots/status"},
-					Verbs:     []string{"update"},
+					Verbs:     []string{"update", "patch"},
 				},
 			},
 		}


### PR DESCRIPTION
## Description

```
lb-csi-controller-0 csi-snapshotter I0218 07:25:15.510567       1 snapshot_controller.go:213] updating VolumeSnapshotContent[snapcontent-9a9f0c55-8ba2-49d7-82d3-cc9825329299] error status failed volumesnapshotcontents.snapshot.storage.k8s.io "snapcontent-9a9f0c55-8ba2-49d7-82d3-cc9825329299" is forbidden: User "system:serviceaccount:kube-system:lb-csi-ctrl-sa" cannot patch resource "volumesnapshotcontents/status" in API group "snapshot.storage.k8s.io" at the cluster scope
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
